### PR TITLE
feat: add option to sort industry state

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Simply connect core and 4 screens in any order (and optionally a databank) to Pr
 Refresh timer - value in seconds, set above 3 for really big factories<br>
 Show name - Will display Industry Unit name instead of the item that is being crafted<br>
 Sort By item tier - Will sort by tier of item being crafted instead of Industry Unit tier <br>
+Sort By State - Sort industry units by their state value <br>
 border - bottom display line position, use to fine tune (increments of 10) if some headers are at the bottom. Maximum is 600.<br>
 tier1colour - Set Tier 1 Colour<br>
 tier2colour - Set Tier 2 Colour<br>
@@ -28,6 +29,9 @@ The script is made so it should be fairly easy to shuffle contents between scree
 
 <br>
 <hr>
+<b>Version 2.5 updates:</b><br>
+    - Added option to sort by state<br>
+<br>
 <b>Version 2.4 updates:</b><br>
     - Added option to sort by item tier instead of Industry Unit tier<br>
     - Added Tier 5 colour parameter<br><br>
@@ -44,7 +48,7 @@ Note: Naming convention is currently as follows:<br>
     - Show indy name Unchecked: Element being crafted then Machine state<br><br>
 
 Thanks to BlimpieBoy for contributions to code.<br>
-Next updates: Planning to allow for State to be set as a prefix or suffix using Parameters and adding in sorting within each tier. <br><br>
+<br>
 
 <b>Version 2.2 updates:</b><br>
     - Can now connect Databank to save Parameters between updates (The first time you connect a Databank it will have no data saved and you should get a message in the Lua chat channel that says "No parameters saved to Databank. Restart the Programming Board"). The Parameters are saved when the Programming Board is deactivated, so do that then re-activate the Programming Board<br>

--- a/source/unit/onStart.lua
+++ b/source/unit/onStart.lua
@@ -9,6 +9,7 @@ system.print ("type 'help' for available commands")
 useDatabankValues = true --export: If checked and if values were saved in databank, parmaters will be loaded from the databank, if not, following ones will be used
 Show_Indy_name = false --export: Shows Industry Unit name instead of element being crafted if checked
 SortByItemTier = true --export: Sort by item tier instead of Industry Unit tier
+SortByState = false --export: Sort machines by state
 State_as_Prefix = false --export: Put state before the machine/item name if checked
 border = 600 --export: Bottom display line<br>Maximum 600<br>Use to adjust
 Refresh_timer = 5 --export: Screen(s) refresh timer in seconds
@@ -29,6 +30,7 @@ options.tier3colour = tier3colour
 options.tier4colour = tier4colour
 options.tier5colour = tier5colour
 options.SortByItemTier = SortByItemTier
+options.SortByState = SortByState
 options.State_as_Prefix = State_as_Prefix
 
 databank = nil

--- a/source/unit/onTimer.lua
+++ b/source/unit/onTimer.lua
@@ -179,15 +179,22 @@ indy_column = function(indy, tier, posx, posy)
             local machines = {}
             for index,id in ipairs(indy) do
                 if (not SortByItemTier) or (getItemTier(id) == tier) then
-                    local machine = {mid = id, name = string.gsub(core_unit[1].getElementNameById(id), "Craft ", "")}
+                    local machine = {
+                        mid = id,
+                        name = string.gsub(core_unit[1].getElementNameById(id), "Craft ", ""),
+                        state = core_unit[1].getElementIndustryInfoById(id)["state"]
+                    }
                     table.insert(machines, machine)
                 end
             end
-                
-            --Sort table by name
-            table.sort(machines, function(a,b) 
+
+            --Sort table by state or name
+            table.sort(machines, function(a,b)
+                if SortByState and a.state ~= b.state then
+                    return a.state < b.state
+                end
                 return a.name < b.name
-                end)
+            end)
                 
             --create table of columns
             for index,machine in ipairs(machines) do
@@ -223,15 +230,22 @@ indy_column = function(indy, tier, posx, posy)
                     if itemInfo and ((not SortByItemTier) or itemInfo["tier"] == tier) then
                         local tempName = itemInfo["displayNameWithSize"]
                         local name = getName(tempName)
-                        table.insert(industryUnits, {mid = id, name = string.lower(name)})
+                        table.insert(industryUnits, {
+                            mid = id,
+                            name = string.lower(name),
+                            state = core_unit[1].getElementIndustryInfoById(id)["state"]
+                        })
                     end
                 end
             end
 
-            --Sort table by name
-            table.sort(industryUnits, function(a,b) 
-                return a.name < b.name 
-                end)
+            --Sort table by state or name
+            table.sort(industryUnits, function(a,b)
+                if SortByState and a.state ~= b.state then
+                    return a.state < b.state
+                end
+                return a.name < b.name
+            end)
 
             --create table of columns
             for index,industryUnit in ipairs(industryUnits) do


### PR DESCRIPTION
## Summary
- add Sort By State parameter (default false)
- allow sorting by industry state when enabled
- document new sorting option and version note

## Testing
- `luac -p source/unit/onStart.lua`
- `luac -p source/unit/onTimer.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c5b617732c832baead0c14d8d9b4ba