### PR TITLE
feat: allow choosing state sort mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Refresh timer - value in seconds, set above 3 for really big factories<br>
 Show name - Will display Industry Unit name instead of the item that is being crafted<br>
 Sort By item tier - Will sort by tier of item being crafted instead of Industry Unit tier <br>
 Sort By State - Sort industry units by their state value <br>
+State Sort Mode - When sorting by state, choose 'A' for alphabetical or 'V' for value-based sorting <br>
 border - bottom display line position, use to fine tune (increments of 10) if some headers are at the bottom. Maximum is 600.<br>
 tier1colour - Set Tier 1 Colour<br>
 tier2colour - Set Tier 2 Colour<br>
@@ -29,6 +30,9 @@ The script is made so it should be fairly easy to shuffle contents between scree
 
 <br>
 <hr>
+<b>Version 2.6 updates:</b><br>
+    - Added parameter to choose alphabetical or value-based state sorting<br>
+
 <b>Version 2.5 updates:</b><br>
     - Added option to sort by state<br>
 <br>

--- a/source/unit/onStart.lua
+++ b/source/unit/onStart.lua
@@ -11,6 +11,7 @@ Show_Indy_name = false --export: Shows Industry Unit name instead of element bei
 SortByItemTier = true --export: Sort by item tier instead of Industry Unit tier
 SortByState = false --export: Sort machines by state
 State_as_Prefix = false --export: Put state before the machine/item name if checked
+StateSortMode = 'V' --export: When sorting by state, 'A' sorts alphabetically and 'V' by value
 border = 600 --export: Bottom display line<br>Maximum 600<br>Use to adjust
 Refresh_timer = 5 --export: Screen(s) refresh timer in seconds
 tier1colour = '0.8, 0.8, 0.8' --export: Set Tier 1 Colour
@@ -32,6 +33,7 @@ options.tier5colour = tier5colour
 options.SortByItemTier = SortByItemTier
 options.SortByState = SortByState
 options.State_as_Prefix = State_as_Prefix
+options.StateSortMode = StateSortMode
 
 databank = nil
 screens = {}

--- a/source/unit/onTimer.lua
+++ b/source/unit/onTimer.lua
@@ -216,8 +216,12 @@ indy_column = function(indy, tier, posx, posy)
 
             --Sort table by state or name
             table.sort(machines, function(a,b)
-                if SortByState and a.stateLabel ~= b.stateLabel then
-                    return a.stateLabel < b.stateLabel
+                if SortByState then
+                    if StateSortMode == 'A' and a.stateLabel ~= b.stateLabel then
+                        return a.stateLabel < b.stateLabel
+                    elseif StateSortMode == 'V' and a.state ~= b.state then
+                        return a.state < b.state
+                    end
                 end
                 return a.name < b.name
             end)
@@ -268,8 +272,12 @@ indy_column = function(indy, tier, posx, posy)
 
             --Sort table by state or name
             table.sort(industryUnits, function(a,b)
-                if SortByState and a.stateLabel ~= b.stateLabel then
-                    return a.stateLabel < b.stateLabel
+                if SortByState then
+                    if StateSortMode == 'A' and a.stateLabel ~= b.stateLabel then
+                        return a.stateLabel < b.stateLabel
+                    elseif StateSortMode == 'V' and a.state ~= b.state then
+                        return a.state < b.state
+                    end
                 end
                 return a.name < b.name
             end)


### PR DESCRIPTION
## Summary
- add `StateSortMode` parameter so state sorting can be alphabetical (`A`) or by value (`V`)
- handle new parameter in sorting logic for machines and industry units
- document state sort mode in README and changelog

## Testing
- `luac -p source/unit/onStart.lua`
- `luac -p source/unit/onTimer.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c5c610506c832ba7d971b6f7044f2e