### PR TITLE
feat: allow configurable background

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Tier 2 Colour - Set Tier 2 Colour<br>
 Tier 3 Colour - Set Tier 3 Colour<br>
 Tier 4 Colour - Set Tier 4 Colour<br>
 Tier 5 Colour - Set Tier 5 Colour<br>
+Background - Set background colour "r, g, b" or image URL<br>
 
 <br>
 Script comes with industry locator. Type <i>help</i> in Lua Tab to see available commands.

--- a/source/unit/onStart.lua
+++ b/source/unit/onStart.lua
@@ -21,6 +21,7 @@ Tier_2_Colour = '0, 1.5, 0' --export: Set Tier 2 Colour
 Tier_3_Colour = '0, 0.15, 1' --export: Set Tier 3 Colour
 Tier_4_Colour = '1, 0, 1.5' --export: Set Tier 4 Colour
 Tier_5_Colour = '2, 0.8, 0' --export: Set Tier 5 Colour
+Background = '' --export: Set background colour "r, g, b" or image URL
 
 system.print("Refresh timer set to: "..Refresh_timer.." seconds")
 
@@ -32,6 +33,7 @@ options.Tier_2_Colour = Tier_2_Colour
 options.Tier_3_Colour = Tier_3_Colour
 options.Tier_4_Colour = Tier_4_Colour
 options.Tier_5_Colour = Tier_5_Colour
+options.Background = Background
 options.Sort_By_Item_Tier = Sort_By_Item_Tier
 options.Sort_By_State = Sort_By_State
 options.State_As_Prefix = State_As_Prefix

--- a/source/unit/onTimer.lua
+++ b/source/unit/onTimer.lua
@@ -376,6 +376,19 @@ if SortByItemTier then
     metalworkAllList = mergeTables(metalwork1, metalwork2, metalwork3, metalwork4)
 end
 
+local background = options.Background or ""
+local backgroundScript = "setNextFillColor(layer,0,0,0,0)\nsetNextStrokeWidth(layer, 1)\naddBoxRounded(layer, 0, 0, rx, ry, 10)\n"
+if background ~= "" then
+    if string.match(string.lower(background), "^%a+://") then
+        backgroundScript = "local bg = loadImage(\""..background.."\")\naddImage(layer,bg,0,0,rx,ry)\nsetNextFillColor(layer,0,0,0,0)\nsetNextStrokeWidth(layer,1)\naddBoxRounded(layer,0,0,rx,ry,10)\n"
+    else
+        local r,g,b = background:match("([%d%.]+)%s*,%s*([%d%.]+)%s*,%s*([%d%.]+)")
+        if r and g and b then
+            backgroundScript = "setNextFillColor(layer,"..r..","..g..","..b..",1)\nsetNextStrokeWidth(layer,1)\naddBoxRounded(layer,0,0,rx,ry,10)\n"
+        end
+    end
+end
+
 screen_one = [[
 local layer = createLayer()
 local rx, ry = getResolution()
@@ -389,9 +402,7 @@ setDefaultFillColor(layer, Shape_Text, 0,0,1,1)
 setDefaultStrokeColor(layer, Shape_Line, 0,.3,2,1)
 setDefaultStrokeColor(layer, Shape_BoxRounded, 0,.3,2,1)
 
-setNextFillColor(layer, 0,0,0,0)
-setNextStrokeWidth(layer, 1)
-addBoxRounded(layer, 0, 0, rx, ry, 10)
+]] .. backgroundScript .. [[
 
 local div = rx/4
 local posy = 10
@@ -439,9 +450,7 @@ setDefaultFillColor(layer, Shape_Text, 0,0,1,1)
 setDefaultStrokeColor(layer, Shape_Line, 0,.3,2,1)
 setDefaultStrokeColor(layer, Shape_BoxRounded, 0,.3,2,1)
 
-setNextFillColor(layer, 0,0,0,0)
-setNextStrokeWidth(layer, 1)
-addBoxRounded(layer, 0, 0, rx, ry, 10)
+]] .. backgroundScript .. [[
 
 local div = rx/4
 local posy = 10
@@ -490,9 +499,7 @@ setDefaultFillColor(layer, Shape_Text, 0,0,1,1)
 setDefaultStrokeColor(layer, Shape_Line, 0,.3,2,1)
 setDefaultStrokeColor(layer, Shape_BoxRounded, 0,.3,2,1)
 
-setNextFillColor(layer, 0,0,0,0)
-setNextStrokeWidth(layer, 1)
-addBoxRounded(layer, 0, 0, rx, ry, 10)
+]] .. backgroundScript .. [[
 
 local div = rx/4
 local posy = 10
@@ -533,9 +540,7 @@ setDefaultFillColor(layer, Shape_Text, 0,0,1,1)
 setDefaultStrokeColor(layer, Shape_Line, 0,.3,2,1)
 setDefaultStrokeColor(layer, Shape_BoxRounded, 0,.3,2,1)
 
-setNextFillColor(layer, 0,0,0,0)
-setNextStrokeWidth(layer, 1)
-addBoxRounded(layer, 0, 0, rx, ry, 10)
+]] .. backgroundScript .. [[
 
 local div = rx/4
 local posy = 10


### PR DESCRIPTION
## Summary
- add `Background` parameter to set custom colour or image for screen backgrounds
- render provided background colour or image across all screens
- document background parameter in README

## Testing
- `luac -p source/unit/onStart.lua source/unit/onStop.lua source/unit/onTimer.lua source/system/onInputText.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c65d568a98832b8971bb70bda7abd1